### PR TITLE
40: Replace C kernel with ECL kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install ECL
+        run: |
+          make setup/ecl
+      
       - name: Install SBCL
         run: |
           make setup/sbcl
-
-      - name: Install cross-compiler toolchain
-        run: |
-          make setup/toolchain
 
       - name: Build kernel [${{ matrix.target-arch }}]
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,6 @@
 
 ## Pull Request And Commit Conventions
 
-- Prefer conventional commit format for PR titles and commits: `type: description`.
-- Common types in this repo include `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`, and `perf:`.
-- Use lowercase, imperative descriptions such as `fix: validate ELF entry point`.
+- Use lowercase, imperative descriptions such as `<issue number>: validate ELF entry point`.
 - Include the issue number in the PR body when applicable, for example `Closes #40`.
 - Prefer short, descriptive branch names. If work is tied to an issue, include the issue number when practical.

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,22 @@ SOURCES   := ecclesia.asd $(wildcard src/*.lisp src/*.asm) $(WRITER)
 ##@ Environment Setup
 
 .PHONY: setup
-setup: setup/hooks setup/sbcl setup/qemu setup/toolchain ## Install all development dependencies
+setup: setup/hooks setup/ecl setup/sbcl setup/qemu ## Install all development dependencies
 
 .PHONY: setup/hooks
 setup/hooks: ## Install git hooks
 	ln -sf "$(PWD)/git/hooks/pre-commit" .git/hooks/pre-commit
 	@echo "✅ Git hooks installed"
+
+.PHONY: setup/ecl
+setup/ecl: ## Install ECL (Embeddable Common Lisp)
+ifeq ($(UNAME_S),Linux)
+	sudo apt update && sudo apt install -y ecl
+else ifeq ($(UNAME_S),Darwin)
+	brew install ecl
+else
+	$(error "Unsupported OS: $(UNAME_S). Please install ECL manually.")
+endif
 
 .PHONY: setup/sbcl
 setup/sbcl: ## Install SBCL
@@ -58,22 +68,6 @@ else ifeq ($(UNAME_S),Darwin)
 	brew install qemu
 else
 	$(error "Unsupported OS: $(UNAME_S). Please install QEMU manually.")
-endif
-
-.PHONY: setup/toolchain
-setup/toolchain: ## Install cross-compilers for supported architectures
-ifeq ($(UNAME_S),Linux)
-	sudo apt update && sudo apt install -y \
-	    gcc \
-	    gcc-x86-64-linux-gnu \
-	    binutils-x86-64-linux-gnu
-	@echo "✅ Cross-compilers installed"
-else ifeq ($(UNAME_S),Darwin)
-	brew install x86_64-elf-gcc 2>/dev/null || \
-	brew install x86_64-elf-binutils
-	@echo "✅ Cross-compilers installed (via Homebrew)"
-else
-	$(error "Unsupported OS: $(UNAME_S). Please install cross-compilers manually.")
 endif
 
 ##@ Development Tasks

--- a/src/kernel/main.lisp
+++ b/src/kernel/main.lisp
@@ -1,0 +1,50 @@
+;;;; main.lisp — Ecclesia kernel entry (ECL-compiled to freestanding ELF)
+
+;;; VGA helpers (freestanding, no libc — use FFI to access 0xB8000 directly)
+
+(defconstant +vga-base+ #xB8000)
+(defconstant +vga-cols+ 80)
+(defconstant +vga-rows+ 25)
+(defconstant +vga-attr-white+ #x0F00)  ;; bright white on black
+(defconstant +vga-attr-cyan+  #x0B00)  ;; bright cyan on black
+(defconstant +vga-attr-gray+  #x0700)  ;; light gray on black
+
+(defun vga-addr (row col)
+  "Get VGA memory address for row/col."
+  (sys:ffi-inline ((row :int) (col :int))
+                  (:pointer :unsigned-short)
+                  "((unsigned short *)0xB8000) + row * 80 + col"))
+
+(defun vga-clear ()
+  "Clear VGA screen to spaces with light gray attribute."
+  (sys:ffi-inline ()
+                  (:void)
+                  "{
+    volatile unsigned short *vga = (volatile unsigned short *)0xB8000;
+    for (int i = 0; i < 80 * 25; i++) {
+      vga[i] = 0x0700 | ' ';
+    }
+  }"))
+
+(defun vga-write (s row col attr)
+  "Write string S to VGA at ROW/COL with ATTR."
+  (sys:ffi-inline ((s :cstring) (row :int) (col :int) (attr :unsigned-short))
+                  (:void)
+                  "{
+    volatile unsigned short *vga = ((volatile unsigned short *)0xB8000) + row * 80 + col;
+    while (*s) {
+      *vga++ = attr | (unsigned char)*s++;
+    }
+  }"))
+
+(defun halt ()
+  "Halt the CPU indefinitely."
+  (sys:ffi-inline () (:void) "{ __asm__ volatile (\"hlt\"); }"))
+
+(defun kernel-main ()
+  ;; Stub: clear VGA, print banner, halt
+  (vga-clear)
+  (vga-write "Ecclesia" 0 0 +vga-attr-cyan+)
+  (vga-write "v0.1" 0 9 +vga-attr-white+)
+  (vga-write "Booted." 1 0 +vga-attr-gray+)
+  (loop (halt)))


### PR DESCRIPTION
Rather than use C directly for our kernel code, are are using Embedded Common Lisp, which lets us inline C as desired.

ECL has many toggles that let us remove or reduce it's need for a garbage collector and other things, so we will add these only as seems required later.